### PR TITLE
Meaningful alt text

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -8,7 +8,7 @@ endif
 
 let b:md_equation_insert_loaded = 1
 
-py import vim
+py3 import vim
 
 " Trim input_string before query
 function! s:Input_Process(input_string)
@@ -16,7 +16,7 @@ function! s:Input_Process(input_string)
     return l:str 
 endfunction
 
-python<<endOfPython
+python3<<endOfPython
 def md_ee_reverse_escape(input_string):
     output_prepare = input_string.replace(u'\ ', u' ')
     output_prepare = output_prepare.replace(u'\\\\', u'\\')
@@ -30,7 +30,7 @@ def md_ee_char_escape(input_string):
 def md_edit_equation():
     web_api = u'http://latex.codecogs.com/gif.latex?'
     cursor = vim.current.window.cursor
-    line = vim.current.buffer[cursor[0] - 1].decode(u'utf-8')
+    line = vim.current.buffer[cursor[0] - 1]
     # original format
     old_format = False
     start = line.rfind(u'![](', 0, cursor[1])
@@ -43,10 +43,10 @@ def md_edit_equation():
         start = line.rfind(u'![eqn](', 0, cursor[1])
     if start == -1:
         start = line.rfind(u'![eqn](', 0, cursor[1] + 7)
-    p_left=1
+    p_left = 1
     end = -1
     if start != -1:
-        for char in zip(range(len(line)),line)[start+(4 if old_format else 7):]:
+        for char in list(zip(range(len(line)),line))[start+(4 if old_format else 7):]:
             if char[1]==u'(':
                 p_left+=1
             elif char[1]==u')':
@@ -75,7 +75,7 @@ endOfPython
 
 
 function! s:edit_equation()
-    py md_edit_equation()
+    py3 md_edit_equation()
 endfunction
 
 command! EditEquation :call <SID>edit_equation()

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -28,48 +28,56 @@ def md_ee_char_escape(input_string):
     return output_prepare
 
 def md_edit_equation():
-    web_api = u'http://latex.codecogs.com/gif.latex?'
+    import re
+
+    web_api = 'http://latex.codecogs.com/gif.latex?'
+    prefix = 'latex equation: '
+    p = re.compile('!\\[' + prefix + '.*?\\]\\(' + web_api + '.*?\\)')
+
     cursor = vim.current.window.cursor
     line = vim.current.buffer[cursor[0] - 1]
-    # original format
-    old_format = False
-    start = line.rfind(u'![](', 0, cursor[1])
-    if start == -1:
-        start = line.rfind(u'![](', 0, cursor[1] + 4)
-    if start != -1:
-        old_format = True
-    # new format
-    if start == -1:
-        start = line.rfind(u'![eqn](', 0, cursor[1])
-    if start == -1:
-        start = line.rfind(u'![eqn](', 0, cursor[1] + 7)
+
+    current = None
+    all_start = -1
+    url_start = -1
+    for match in p.finditer(line):
+        span = match.span()
+        if cursor[1] >= span[0] and cursor[1] < span[1]:
+            current = match
+            all_start = match.span()[0]
+            url_start = line.find(web_api, all_start)
+
     p_left = 1
     end = -1
-    if start != -1:
-        for char in list(zip(range(len(line)),line))[start+(4 if old_format else 7):]:
-            if char[1]==u'(':
-                p_left+=1
-            elif char[1]==u')':
-                p_left-=1
-            if p_left==0:
+
+    if all_start != -1:
+        for char in list(zip(range(len(line)), line))[url_start:]:
+            if char[1] == u'(':
+                p_left += 1
+            elif char[1] == u')':
+                p_left -= 1
+            if p_left == 0:
                 end = char[0]
                 break
+
     content = ""
     md_insert_new_equation = False
-    if start==-1 or end==-1:
+    if all_start == -1 or end == -1:
         md_insert_new_equation = True
     else:
-        content = md_ee_reverse_escape(line[start+(4 if old_format else 7):end].replace(web_api,''))
+        content = md_ee_reverse_escape(line[url_start:end].replace(web_api,''))
+
     new_equation = vim.eval("input('Type the equation(in latex format):\n', \"{}\")".format(content.replace('\\','\\\\')))
+
     if md_insert_new_equation:
         if not new_equation:
             return
-        vim.command('normal! i![eqn]('+web_api+md_ee_char_escape(new_equation)+')')
+        vim.command('normal! i![' + prefix + new_equation.replace('[', '{').replace(']', '}') + '](' + web_api + md_ee_char_escape(new_equation) + ')')
     else:
         if not new_equation:
             vim.command('echom "Detect empty equation input, quitting"')
             return
-        line=line[:start]+'![eqn]('+web_api+md_ee_char_escape(new_equation)+line[end:]
+        line = line[:all_start] + '![' + prefix + new_equation.replace('[', '{').replace(']', '}') + '](' + web_api + md_ee_char_escape(new_equation) + line[end:]
         vim.current.buffer[cursor[0] - 1] = line
 endOfPython
 


### PR DESCRIPTION
Plugin is edited for Python3, hence +python3 version of Vim is required.
Meaningful captions for images like "latex equation: eqn".

Fixes Ron89/md_insert_equation.vim#2 and Ron89/md_insert_equation.vim#1
